### PR TITLE
Prevent frivolous exceptions

### DIFF
--- a/_Code/Entities/Spawnpoints.cs
+++ b/_Code/Entities/Spawnpoints.cs
@@ -160,8 +160,8 @@ namespace VivHelper.Entities {
             if (scene is Level level) {
                 try {
                     LevelData l = level.Session.MapData.Levels.First(_l => _l.Name == level.Session.Level);
-                    var e = l.Entities.First(_e => trueSpawnPoints.Contains(_e.Name) && _e.Position == self.Position);
-                    if (e.Bool("forceFacing", true))
+                    var e = l.Entities.FirstOrDefault(_e => trueSpawnPoints.Contains(_e.Name) && _e.Position == self.Position);
+                    if (e != null && e.Bool("forceFacing", true))
                         self.Facing = e.Bool("flipX", false) ? Facings.Left : Facings.Right;
                     return;
 

--- a/_Code/Module, Extensions, Etc/CustomDashStateCh.cs
+++ b/_Code/Module, Extensions, Etc/CustomDashStateCh.cs
@@ -258,6 +258,9 @@ namespace VivHelper {
         }
 
         public static void LoadPresets() {
+            if (presetCustomBoosterStates.ContainsKey("Default")) {
+                presetCustomBoosterStates.Remove("Default");
+            }
             presetCustomBoosterStates.Add("Default", new EntityData {
                 Values = new Dictionary<string, object>
                 {
@@ -267,6 +270,9 @@ namespace VivHelper {
                     {"ColorSet", "000000,8cf7cf,4acfc6,1c7856,0e4a36,172b21,0e1c15,ffffff,291c33" }
                 }
             });
+            if (presetCustomBoosterStates.ContainsKey("Superdash")) {
+                presetCustomBoosterStates.Remove("Superdash");
+            }
             presetCustomBoosterStates.Add("Superdash", new EntityData {
                 Values = new Dictionary<string, object>
                 {
@@ -278,6 +284,9 @@ namespace VivHelper {
                     {"ColorSet", "000000,5cd4ff,5ca6e5,005c7b,003146,192d33,191922,ffffff,291c33" },
                 }
             });
+            if (presetCustomBoosterStates.ContainsKey("FragileDash")) {
+                presetCustomBoosterStates.Remove("FragileDash");
+            }
             presetCustomBoosterStates.Add("FragileDash", new EntityData {
                 Values = new Dictionary<string, object>
                 {
@@ -287,6 +296,9 @@ namespace VivHelper {
                     {"ColorSet", "000000,ffffa7,b2ef5f,84912e,555f1f,3e3e28,2e2e1f,ffffff,291c33" },
                 }
             });
+            if (presetCustomBoosterStates.ContainsKey("HeldDash")) {
+                presetCustomBoosterStates.Remove("HeldDash");
+            }
             presetCustomBoosterStates.Add("HeldDash", new EntityData {
                 Values = new Dictionary<string, object>
                 {
@@ -297,6 +309,9 @@ namespace VivHelper {
                     {"ColorSet", "000000,f1ceab,e5a565,9c5b1a,5f3f10,3d230a,271707,ffffff,291c33" },
                 }
             });
+            if (presetCustomBoosterStates.ContainsKey("DoubleSpeed")) {
+                presetCustomBoosterStates.Remove("DoubleSpeed");
+            }
             presetCustomBoosterStates.Add("DoubleSpeed", new EntityData {
                 Values = new Dictionary<string, object>
                 {
@@ -306,6 +321,9 @@ namespace VivHelper {
                     {"ColorSet", "000000,ceffff,62ffff,16ad75,006241,0e2f1e,00160b,ffffff,291c33" },
                 }
             });
+            if (presetCustomBoosterStates.ContainsKey("HeldSuperdash")) {
+                presetCustomBoosterStates.Remove("HeldSuperdash");
+            }
             presetCustomBoosterStates.Add("HeldSuperdash", new EntityData {
                 Values = new Dictionary<string, object>
                 {


### PR DESCRIPTION
I'm on a crusade to reduce the number of exceptions that get thrown during normal gameplay, including caught exceptions. It tanks performance, especially with the VS debugger attached, and interferes with my efforts to debug my own stuff.

Previously, VivHelper threw and caught an exception every time the player respawns at a spawn point that is not a vivhelper "spawn facing direction" spawnpoint (so almost every time). This PR handles the case that causes the error without that exception getting thrown.

This PR also adds guardrails against a crash that previously occurred when hot-reloading the code module.